### PR TITLE
Myip plugin improvements

### DIFF
--- a/agent2/plugins/myip/.gitignore
+++ b/agent2/plugins/myip/.gitignore
@@ -1,0 +1,3 @@
+go.mod
+go.sum
+myip

--- a/agent2/plugins/myip/Makefile
+++ b/agent2/plugins/myip/Makefile
@@ -7,6 +7,7 @@ main: clean
 install: main
 	install -d /usr/local/zabbix/go/plugins
 	install myip /usr/local/zabbix/go/plugins
+	install --mode=0644 myip.conf /etc/zabbix/zabbix_agent2.d/plugins.d
 
 clean:
 	rm -f myip *.mod *.sum

--- a/agent2/plugins/myip/README.md
+++ b/agent2/plugins/myip/README.md
@@ -12,10 +12,6 @@ running. In order to build the plugin you need to be connected to the Internet.
 
        sudo make install
 
-1. Configure it in Zabbix agent 2:
-
-       echo Plugins.Myip.System.Path=/usr/local/zabbix/go/plugins/myip | sudo tee /etc/zabbix/zabbix_agent2.d/plugins.d/myip.conf
-
 1. Test it:
 
        zabbix_agent2 -t myip

--- a/agent2/plugins/myip/myip.conf
+++ b/agent2/plugins/myip/myip.conf
@@ -1,0 +1,1 @@
+Plugins.Myip.System.Path=/usr/local/zabbix/go/plugins/myip


### PR DESCRIPTION
Instead of asking user to copy-paste commands, add plugin configuration as part of `make install`.